### PR TITLE
Fix for birth time support-ing JDKs

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJavaNio.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJavaNio.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.hosted.jdk;
 
+import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -38,6 +39,7 @@ import org.graalvm.nativeimage.impl.InternalPlatform;
 import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.feature.InternalFeature;
 import com.oracle.svm.core.jdk.JNIRegistrationUtil;
+import com.oracle.svm.util.ReflectionUtil;
 
 /**
  * Registration of classes, methods, and fields accessed via JNI by C code of the JDK.
@@ -155,8 +157,13 @@ public class JNIRegistrationJavaNio extends JNIRegistrationUtil implements Inter
         RuntimeJNIAccess.register(fields(a, "sun.nio.fs.UnixFileAttributes",
                         "st_mode", "st_ino", "st_dev", "st_rdev", "st_nlink", "st_uid", "st_gid", "st_size",
                         "st_atime_sec", "st_atime_nsec", "st_mtime_sec", "st_mtime_nsec", "st_ctime_sec", "st_ctime_nsec"));
-        if (isDarwin()) {
+        // See JDK-8316304, new in JDK 17.0.11+1
+        Field unixCreationTimeField = ReflectionUtil.lookupField(true, clazz(a, "sun.nio.fs.UnixFileAttributes"), "st_birthtime_nsec");
+        if (isDarwin() || unixCreationTimeField != null) {
             RuntimeJNIAccess.register(fields(a, "sun.nio.fs.UnixFileAttributes", "st_birthtime_sec"));
+        }
+        if (unixCreationTimeField != null) {
+            RuntimeJNIAccess.register(fields(a, "sun.nio.fs.UnixFileAttributes", "st_birthtime_nsec"));
         }
 
         RuntimeJNIAccess.register(clazz(a, "sun.nio.fs.UnixFileStoreAttributes"));


### PR DESCRIPTION
We'd like to get this fix into the GraalVM for JDK 17 community backports. See the details in https://github.com/graalvm/mandrel/issues/680, specifically https://github.com/graalvm/mandrel/issues/680#issuecomment-1966922041.

The upstream JDK bug for this is [JDK-8316304](https://bugs.openjdk.org/browse/JDK-8316304), which is new in OpenJDK 17.0.11 (to be released this April).

@ezzarghili @zakkak Thoughts?